### PR TITLE
Removed unnecessary slash causing download to not work.

### DIFF
--- a/module/download_bucket_public.py
+++ b/module/download_bucket_public.py
@@ -77,7 +77,7 @@ def download_files(bucket, keys):
 
                     #Try to download the file.  Some will fail because they are directories
                     try:
-                        url = '{url}/{key}'.format(url=bucket.url, key=key)
+                        url = '{url}{key}'.format(url=bucket.url, key=key)
                         print "  Downloading %s" % (url)
                         urllib.urlretrieve(url, file_name)
                         print "    FINISHED"


### PR DESCRIPTION
Unauthorised download failed to work - ran fine but failed to actually store files locally. Removing slash fixed.